### PR TITLE
Adding Sourcing Arch Image from Atom Feed

### DIFF
--- a/.github/workflows/docker-build-tag-and-publish.yaml
+++ b/.github/workflows/docker-build-tag-and-publish.yaml
@@ -55,6 +55,10 @@ jobs:
           docker rmi $(docker image ls -aq)
           df -h
           docker system prune --all --force
+      - name: Get Latest Arch Tag
+        id: archtag
+        shell: pwsh
+        run: $tag=(Invoke-RestMethod "https://gitlab.archlinux.org/archlinux/archlinux-docker/-/tags?format=atom" | Sort-Object -Property updated -Descending | Select-Object -First 1 | Select-Object -ExpandProperty title).Replace("v", [string]::Empty) >> "$GITHUB_OUTPUT"
       - name: Check out code
         uses: actions/checkout@v4.1.1
       - name: Login to Docker Hub
@@ -72,6 +76,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
+          build-args: tag=${{ steps.archtag.outputs.tag }}
           context: ${{ github.workspace }}
           file: ./Arch/Dockerfile
           push: true

--- a/Arch/Dockerfile
+++ b/Arch/Dockerfile
@@ -1,5 +1,6 @@
+ARG tag
 
-FROM archlinux:base-devel-20240101.0.204074 as toolsbuilder
+FROM archlinux/archlinux:base-devel-${tag} as toolsbuilder
 
 # Fix for pipx breaking docker output (via emoji)
 ENV USE_EMOJI=false
@@ -30,7 +31,7 @@ RUN pacman-key --init \
     && su - builder -c "git clone https://aur.archlinux.org/mssql-tools.git" \
     && su - builder -c "cd mssql-tools && (makepkg -sirc --noconfirm > /dev/null 2>&1)"
 
-FROM archlinux:base-20240101.0.204074 as intermediary
+FROM archlinux/archlinux:base-${tag} as intermediary
 
 ARG Azure_Powershell_Version=11.2.0
 ARG Helm_Version=v3.7.1


### PR DESCRIPTION
This PR modifies the Arch Dockerfile and the GitHub Action to supply the latest date tag from the Atom Feed for the tags, which we can use to statically assign a new tag to the latest daily tag (given a bug in the weekly tags in the current official repository).