### PR TITLE
Major Update: Adding Support for Pass via Docker Login

### DIFF
--- a/.github/workflows/docker-build-tag-and-publish.yaml
+++ b/.github/workflows/docker-build-tag-and-publish.yaml
@@ -55,10 +55,13 @@ jobs:
           docker rmi $(docker image ls -aq)
           df -h
           docker system prune --all --force
-      - name: Get Latest Arch Tag
-        id: archtag
-        shell: pwsh
-        run: $tag=(Invoke-RestMethod "https://gitlab.archlinux.org/archlinux/archlinux-docker/-/tags?format=atom" | Sort-Object -Property updated -Descending | Select-Object -First 1 | Select-Object -ExpandProperty title).Replace("v", [string]::Empty); Write-Output "tag=$($tag)" >> $env:GITHUB_OUTPUT
+      - name: Get Latest Daily Arch Tag
+        id: dailyarchtag
+        shell: bash
+        run: |
+            VERSION=$(curl -s https://gitlab.archlinux.org/archlinux/archlinux-docker/-/tags?format=atom | xq -r '.feed.entry[0].title')
+            FIXED_VERSION=$(echo "${VERSION//v}")
+            echo "tag=${FIXED_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Check out code
         uses: actions/checkout@v4.1.1
       - name: Login to Docker Hub
@@ -76,7 +79,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
-          build-args: tag=${{ steps.archtag.outputs.tag }}
+          build-args: tag=${{ steps.dailyarchtag.outputs.tag }}
           context: ${{ github.workspace }}
           file: ./Arch/Dockerfile
           push: true

--- a/Alpine.3.19/Dockerfile
+++ b/Alpine.3.19/Dockerfile
@@ -7,13 +7,22 @@ ARG Helm_Version=v3.7.1
 ARG Kubelogin_Version=v0.0.30
 ARG Terraform_Version=1.6.6
 
-RUN apk update \
+ARG User=octoworker
+ARG Group=octoworker
+
+COPY keygen.sh /keygen.sh
+
+RUN addgroup -S ${Group} \
+    && adduser --disabled-password --ingroup ${Group} --shell /bin/bash ${User} \
+    && apk update \
     && apk add --upgrade apk-tools \
     && apk upgrade --available \
     # Install .NET and PowerShell dependencies
-    && apk add --no-cache bash ca-certificates cargo curl gcompat icu-libs krb5-libs less libffi-dev libgcc libintl libstdc++ make musl-dev ncurses-terminfo-base openssl openssl-dev pipx python3-dev py3-pip tzdata userspace-rcu zlib \
+    && apk add --no-cache bash ca-certificates cargo coreutils curl docker gcompat grep icu-libs krb5-libs less libffi-dev \
+        libgcc libintl libstdc++ make musl-dev ncurses-terminfo-base openssl openssl-dev pass pipx python3-dev py3-pip tzdata \
+        userspace-rcu zlib \
     && apk -X https://dl-cdn.alpinelinux.org/alpine/community/ add --no-cache umoci \
-    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust \
+    && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust gnupg \
     && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/testing add --no-cache libssl1.1 \
     # .NET8 did not ship with 3.19 (See: https://github.com/dotnet/sdk/issues/37790)
     && apk -X https://dl-cdn.alpinelinux.org/alpine/edge/community add --no-cache aspnetcore8-runtime dotnet8-runtime dotnet8-sdk \
@@ -65,8 +74,19 @@ RUN apk update \
     && az extension add --name azure-devops \
     && az extension add --name azure-firewall \
     && az extension add --name functionapp \
-    && az extension add --name webapp
+    && az extension add --name webapp \
+    && chmod +x /keygen.sh
 
-FROM scratch as final
+FROM scratch as intermediary
 
+ARG User=octoworker
 COPY --from=builder / /
+
+USER ${User}
+RUN mkdir -p /home/${User}/.docker/ \
+    && touch /home/${User}/.docker/config.json \
+    && printf "{\n\t\"credsStore\":\"pass\"\n}\n" >> /home/${User}/.docker/config.json \
+    && export GPG_TTY=$(tty) \
+    && /keygen.sh \
+    && fingerprint=$(gpg2 --list-keys | grep -Po '\w{20,}') \
+    && pass init $(echo $fingerprint)

--- a/Alpine.3.19/keygen.sh
+++ b/Alpine.3.19/keygen.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S gpg2 --batch --expert --gen-key
+# Brief: Generate ECC PGP keys for signing (primary key) & encryption (subkey)
+# Run as: chmod +x gpg_ecc-25519_keygen; ./gpg_ecc-25519_keygen
+# Ref: https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
+
+%echo "Generating ECC keys (sign & encr) with no-expiry"
+  %no-protection
+  Key-Type: EDDSA
+    Key-Curve: ed25519
+  Subkey-Type: ECDH
+    Subkey-Curve: cv25519
+  Name-Real: octoworker
+  Expire-Date: 0
+  # Now, let's do a commit here, so that we can later print "done" :-)
+  %commit
+%echo Done

--- a/Arch/Dockerfile
+++ b/Arch/Dockerfile
@@ -1,122 +1,77 @@
 ARG tag
 
-FROM archlinux/archlinux:base-devel-${tag} as toolsbuilder
-
-# Fix for pipx breaking docker output (via emoji)
-ENV USE_EMOJI=false
-
-# NOTE: makepkg output goes via stderror, so we have to silence this or we fill the runner's build log and the build fails.
-RUN pacman-key --init \
-    && pacman -Syu --noconfirm \
-    && pacman -S --noconfirm cargo git go go-md2man make python python-pipx \
-    && useradd -m -G wheel builder \
-    && passwd -d builder \
-    && echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
-    # Install Az CLI
-    && pipx ensurepath \
-    && pipx install azure-cli \
-    # Make Umoci to Get Around CVEs (No New Releases Published Since 2022)
-    && git clone https://github.com/opencontainers/umoci.git \
-    && cd umoci \
-    && make -si DESTDIR=/ install > /dev/null \
-    && cd / \
-    && rm -rf umoci \
-    # Make MSFT SQL Server Tools
-    && su - builder -c "git clone https://aur.archlinux.org/libldap24.git" \
-    && su - builder -c "cd libldap24 && (makepkg -sirc --noconfirm > /dev/null 2>&1)" \
-    && su - builder -c "git clone https://aur.archlinux.org/mssql-server.git" \
-    && su - builder -c "cd mssql-server && (makepkg -sirc --noconfirm > /dev/null 2>&1)" \
-    && su - builder -c "git clone https://aur.archlinux.org/msodbcsql.git" \
-    && su - builder -c "cd msodbcsql && (makepkg -sirc --noconfirm > /dev/null 2>&1)" \
-    && su - builder -c "git clone https://aur.archlinux.org/mssql-tools.git" \
-    && su - builder -c "cd mssql-tools && (makepkg -sirc --noconfirm > /dev/null 2>&1)"
-
-FROM archlinux/archlinux:base-${tag} as intermediary
+FROM archlinux/archlinux:base-${tag} as builder
 
 ARG Azure_Powershell_Version=11.2.0
 ARG Helm_Version=v3.7.1
-ARG Kubelogin_Version=v0.0.30
-ARG Octopus_Client_Version=9.1.7
-ARG Powershell_Version=7.4.1
-ARG Terraform_Version=1.6.6-1
+ARG Kubelogin_Version=v0.1.1
 
-COPY --from=toolsbuilder home/builder/libldap24/libldap24-2.4.59-2-x86_64.pkg.tar.zst /libldap24-2.4.59-2-x86_64.pkg.tar.zst
-COPY --from=toolsbuilder home/builder/mssql-server/mssql-server-16.0.4105.2-1-x86_64.pkg.tar.zst /mssql-server-16.0.4105.2-1-x86_64.pkg.tar.zst
-COPY --from=toolsbuilder home/builder/msodbcsql/msodbcsql-18.3.2.1-2-x86_64.pkg.tar.zst /msodbcsql-18.3.2.1-2-x86_64.pkg.tar.zst
-COPY --from=toolsbuilder home/builder/mssql-tools/mssql-tools-18.2.1.1-1-x86_64.pkg.tar.zst /mssql-tools-18.2.1.1-1-x86_64.pkg.tar.zst
-COPY --from=toolsbuilder /usr/local/bin/umoci /usr/local/bin/umoci
-# IMPORTANT: The preceding and trailing '.' are required to not overwrite any existing files altogether (if any)
-COPY --from=toolsbuilder ./root/.local/. /root/.local/
+COPY keygen.sh /keygen.sh
+COPY pacman.conf /etc/pacman.conf
+COPY chaotic-mirrorlist /etc/pacman.d/chaotic-mirrorlist
 
-ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
-ENV DOTNET_NOLOGO=true
-ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ARG User=octoworker
+ARG Group=octoworker
 
-RUN pacman-key --init \
-    && pacman -Syy --noconfirm \
-    && pacman -Syu --noconfirm \
-    && pacman -U --noconfirm /libldap24-2.4.59-2-x86_64.pkg.tar.zst \
-    && pacman -U --noconfirm /mssql-server-16.0.4105.2-1-x86_64.pkg.tar.zst \
-    && pacman -U --noconfirm /msodbcsql-18.3.2.1-2-x86_64.pkg.tar.zst \
-    && pacman -U --noconfirm /mssql-tools-18.2.1.1-1-x86_64.pkg.tar.zst \
-    && rm -f /libldap24-2.4.59-2-x86_64.pkg.tar.zst \
-    && rm -f /mssql-server-16.0.4105.2-1-x86_64.pkg.tar.zst \
-    && rm -f /msodbcsql-18.3.2.1-2-x86_64.pkg.tar.zst \
-    && rm -f /mssql-tools-18.2.1.1-1-x86_64.pkg.tar.zst \
-    && pacman -S --noconfirm aspnet-runtime-8.0 bash ca-certificates curl diffutils dotnet-runtime-8.0 dotnet-sdk-8.0 git glibc gnupg gradle groff libffi maven openssl rsync skopeo tar unzip wget \
+RUN groupadd ${Group} \
+    && useradd -m -g ${Group} -s /bin/bash ${User} \
+    && pacman-key --init \
+    # Populate Arch Linux Keys.
+    && pacman-key --populate archlinux \
+    # Receive Chaotic AUR Key.
+    && pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com \
+    # Sign Chaotic AUR Key.
+    && pacman-key --lsign-key 3056513887B78AEB \
+    # Add Chaotic AUR Keyring.
+    && pacman --noconfirm -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' \
+    && pacman --noconfirm -Syyu \
+    && pacman --noconfirm -S aspnet-runtime chaotic-aur/azure-cli curl dotnet-runtime dotnet-sdk extra/argocd extra/code \
+        extra/docker extra/eksctl extra/gradle core/groff extra/jq extra/kubectl extra/maven extra/nodejs extra/rsync \
+        extra/skopeo extra/terraform extra/umoci extra/yq gnupg nano pass powershell unzip wget \
+    # Install ECS CLI
+    && curl --silent --location "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-v${Ecs_Cli_Version}" -o /usr/local/bin/ecs-cli \
+    && chmod +x /usr/local/bin/ecs-cli \
     # Install Helm 3
     && wget --quiet -O - https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash -s -- -v ${Helm_Version} \
     # Install Istio CLI
     && curl -sL https://istio.io/downloadIstioctl | sh - \
     && mv /root/.istioctl/bin/istioctl /usr/local/bin/istioctl \
     && rm -rf /root/.istioctl \
-    # Install kubectl
-    && curl -LO https://dl.k8s.io/release/v1.29.1/bin/linux/amd64/kubectl \
-    && mv kubectl /usr/local/bin \
-    # Install kubelogin
-    && wget https://github.com/Azure/kubelogin/releases/download/${Kubelogin_Version}/kubelogin-linux-amd64.zip \
-    && unzip kubelogin-linux-amd64.zip -d kubelogin-linux-amd64 \
-    && mv kubelogin-linux-amd64/bin/linux_amd64/kubelogin /usr/local/bin \
-    && rm -rf kubelogin-linux-amd64 \
-    && rm kubelogin-linux-amd64.zip \
     # Install Linkerd CLI
     && curl -sL https://run.linkerd.io/install | sh \
     && mv /root/.linkerd2/bin/linkerd /usr/local/bin \
     && rm -rf /root/.linkerd2 \
     # Install octopus-cli
     && curl -L https://github.com/OctopusDeploy/cli/raw/main/scripts/install.sh | bash \
-    # Install octopuscli
-    && wget -O OctopusTools.9.1.7.linux-x64.tar.gz https://download.octopusdeploy.com/octopus-tools/9.1.7/OctopusTools.9.1.7.linux-x64.tar.gz \
-    && tar zxf OctopusTools.9.1.7.linux-x64.tar.gz \
-    && rm -f OctopusTools.9.1.7.linux-x64.tar.gz \
-    && mv octo /usr/bin/octo \
-    && chmod +x /usr/bin/octo \
-    # Install PowerShell
-    && curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v${Powershell_Version}/powershell-${Powershell_Version}-linux-x64.tar.gz \
-    && mkdir -p /opt/microsoft/powershell/7 \
-    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \
-    && rm -f /tmp/powershell.tar.gz \
-    && chmod +x /opt/microsoft/powershell/7/pwsh \
-    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh \
-    # Install Octopus.Client
-    && pwsh -c 'Install-Package -Force Octopus.Client -MaximumVersion "'${Octopus_Client_Version}'" -source https://www.nuget.org/api/v2 -SkipDependencies -Verbose' \
-    && octopusClientPackagePath=$(pwsh -c '(Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName') \
-    && cp -r $octopusClientPackagePath/lib/netstandard2.0/* . \
     # Install Az PowerShell Module(s)
     && pwsh -c 'Install-Module -Force -Name Az -AllowClobber -Scope AllUsers -MaximumVersion "'${Azure_Powershell_Version}'" -Verbose' \
-    # Install Az CLI
-    && ln -s /root/.local/bin/az /usr/bin/az \
     # Disable Az CLI Telemetry Collection
     && az config set core.collect_telemetry=no \
-    # Add Az CLI Extensions
-    && az extension add --name azure-devops \
-    && az extension add --name azure-firewall \
-    && az extension add --name functionapp \
-    && az extension add --name webapp \
-    # Install Terraform from Archive Package[s]
-    && pacman -U --noconfirm https://archive.archlinux.org/packages/t/terraform/terraform-${Terraform_Version}-x86_64.pkg.tar.zst \
-    && pacman -Scc --noconfirm
+    # Install Azure Kubelogin
+    && wget --quiet https://github.com/Azure/kubelogin/releases/download/${Kubelogin_Version}/kubelogin-linux-amd64.zip \
+    && unzip kubelogin-linux-amd64.zip -d kubelogin-linux-amd64 \
+    && mv kubelogin-linux-amd64/bin/linux_amd64/kubelogin /usr/local/bin \
+    && rm -rf kubelogin-linux-amd64 \
+    && rm kubelogin-linux-amd64.zip \
+    # Setup for Docker Credentials Helper
+    && chmod +x /keygen.sh \
+    && gpg2 --update-trustdb \
+    && wget -O /usr/bin/docker-credential-pass https://github.com/docker/docker-credential-helpers/releases/download/v0.8.1/docker-credential-pass-v0.8.1.linux-amd64 \
+    && chmod +x /usr/bin/docker-credential-pass \
+    && pacman --noconfirm -Scc
 
-FROM scratch as final
+FROM scratch as intermediary
 
-COPY --from=intermediary / /
+ARG User=octoworker
+COPY --from=builder / /
+
+USER ${User}
+RUN mkdir -p /home/${User}/.docker/ \
+    && touch /home/${User}/.docker/config.json \
+    && printf "{\n\t\"credsStore\":\"pass\"\n}\n" >> /home/${User}/.docker/config.json \
+    && export GPG_TTY=$(tty) \
+    && /keygen.sh \
+    && fingerprint=$(gpg2 --list-keys | grep -Po '\w{20,}') \
+    && pass init $(echo $fingerprint) \
+    # Build-Kit Sandbox keeps a lock, so let's remove it
+    && rm ~/.gnupg/public-keys.d/pubring.db.lock

--- a/Arch/chaotic-mirrorlist
+++ b/Arch/chaotic-mirrorlist
@@ -1,0 +1,75 @@
+# Special CDN mirror (delayed syncing, expect some (safe to ignore) amount of 404s)
+# Globally
+# * By: Garuda Linux donators, hosted on Cloudflare R2
+Server = https://cdn-mirror.chaotic.cx/$repo/$arch
+
+# Automatic per-country routing of the mirrors below.
+Server = https://geo-mirror.chaotic.cx/$repo/$arch
+
+## Regular Syncthing mirrors (close to instant syncing)
+# Brazil
+# * By: Universidade Federal de São Carlos (São Carlos)
+Server = https://br-mirror.chaotic.cx/$repo/$arch
+
+# Bulgaria
+# * By: Sudo Man <github.com/sakrayaami>
+Server = https://bg-mirror.chaotic.cx/$repo/$arch
+
+# Canada
+# * By freebird54 (Toronto)
+Server = https://ca-mirror.chaotic.cx/$repo/$arch
+
+# Chile
+# * By makzk (Santiago)
+Server = https://cl-mirror.chaotic.cx/$repo/$arch
+
+# Germany (de-1 ceased to exist)
+# * By: ParanoidBangL
+Server = https://de-2-mirror.chaotic.cx/$repo/$arch
+# * By: itsTyrion
+Server = https://de-3-mirror.chaotic.cx/$repo/$arch
+# * By: redgloboli
+Server = https://de-4-mirror.chaotic.cx/$repo/$arch
+
+# France
+# * By Yael (Marseille)
+Server = https://fr-mirror.chaotic.cx/$repo/$arch
+
+# Greece
+# * By: vmmaniac <github.com/vmmaniac>
+Server = https://gr-mirror.chaotic.cx/$repo/$arch
+
+# India
+# * By Naman (Kaithal)
+Server = https://in-mirror.chaotic.cx/$repo/$arch
+# * By Albony <https://albony.xyz/>
+Server = https://in-2-mirror.chaotic.cx/$repo/$arch
+# * By: BRAVO68DEV <https://www.itsmebravo.dev/>
+Server = https://in-3-mirror.chaotic.cx/$repo/$arch
+# * By Albony (Chennai)
+Server = https://in-4-mirror.chaotic.cx/$repo/$arch
+
+# Korea
+# * By: <t.me/silent_heigou> (Seoul)
+Server = https://kr-mirror.chaotic.cx/$repo/$arch
+
+# Spain
+# * By: JKANetwork
+Server = https://es-mirror.chaotic.cx/$repo/$arch
+# * By: Ícar <t.me/IcarNS>
+Server = https://es-2-mirror.chaotic.cx/$repo/$arch
+
+# United States
+# * By: Technetium1 <github.com/Technetium1>
+Server = https://us-mi-mirror.chaotic.cx/$repo/$arch
+# New York
+# * By: xstefen <t.me/xstefen>
+Server = https://us-tx-mirror.chaotic.cx/$repo/$arch
+# Utah
+# * By: ash <t.me/the_ashh>
+Server = https://us-ut-mirror.chaotic.cx/$repo/$arch
+
+
+# IPFS mirror - for instructions on how to use it consult the projects repo (https://github.com/RubenKelevra/pacman.store)
+# * By: RubenKelevra / pacman.store
+# Server = http://chaotic-aur.pkg.pacman.store.ipns.localhost:8080/$arch

--- a/Arch/keygen.sh
+++ b/Arch/keygen.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S gpg2 --batch --expert --gen-key
+# Brief: Generate ECC PGP keys for signing (primary key) & encryption (subkey)
+# Run as: chmod +x gpg_ecc-25519_keygen; ./gpg_ecc-25519_keygen
+# Ref: https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
+
+%echo "Generating ECC keys (sign & encr) with no-expiry"
+  %no-protection
+  Key-Type: EDDSA
+    Key-Curve: ed25519
+  Subkey-Type: ECDH
+    Subkey-Curve: cv25519
+  Name-Real: octoworker
+  Expire-Date: 0
+  # Now, let's do a commit here, so that we can later print "done" :-)
+  %commit
+%echo Done

--- a/Arch/pacman.conf
+++ b/Arch/pacman.conf
@@ -1,0 +1,107 @@
+#
+# /etc/pacman.conf
+#
+# See the pacman.conf(5) manpage for option and repository directives
+
+#
+# GENERAL OPTIONS
+#
+[options]
+# The following paths are commented out with their default values listed.
+# If you wish to use different paths, uncomment and update the paths.
+#RootDir     = /
+#DBPath      = /var/lib/pacman/
+#CacheDir    = /var/cache/pacman/pkg/
+#LogFile     = /var/log/pacman.log
+#GPGDir      = /etc/pacman.d/gnupg/
+#HookDir     = /etc/pacman.d/hooks/
+HoldPkg      = pacman glibc
+#XferCommand = /usr/bin/curl -L -C - -f -o %o %u
+#XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+#CleanMethod = KeepInstalled
+Architecture = auto
+
+# Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
+#IgnorePkg   =
+#IgnoreGroup =
+
+#NoUpgrade   =
+#NoExtract   =
+
+# Misc options
+#UseSyslog
+Color
+#NoProgressBar
+CheckSpace
+VerbosePkgLists
+ParallelDownloads = 8
+ILoveCandy
+DisableDownloadTimeout
+
+# By default, pacman accepts packages signed by keys that its local keyring
+# trusts (see pacman-key and its man page), as well as unsigned packages.
+SigLevel = Required DatabaseOptional
+LocalFileSigLevel = Optional
+#RemoteFileSigLevel = Required
+
+# NOTE: You must run `pacman-key --init` before first using pacman; the local
+# keyring can then be populated with the keys of all official Arch Linux
+# packagers with `pacman-key --populate archlinux`.
+
+#
+# REPOSITORIES
+#   - can be defined here or included from another file
+#   - pacman will search repositories in the order defined here
+#   - local/custom mirrors can be added here or in separate files
+#   - repositories listed first will take precedence when packages
+#     have identical names, regardless of version number
+#   - URLs will have $repo replaced by the name of the current repo
+#   - URLs will have $arch replaced by the name of the architecture
+#
+# Repository entries are of the format:
+#       [repo-name]
+#       Server = ServerName
+#       Include = IncludePath
+#
+# The header [repo-name] is crucial - it must be present and
+# uncommented to enable the repo.
+#
+
+# The testing repositories are disabled by default. To enable, uncomment the
+# repo name header and Include lines. You can add preferred servers immediately
+# after the header, and they will be used before the default mirrors.
+
+#[core-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[core]
+SigLevel = PackageRequired TrustedOnly
+Include = /etc/pacman.d/mirrorlist
+
+[community]
+SigLevel = PackageRequired TrustedOnly
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+SigLevel = PackageRequired TrustedOnly
+Include = /etc/pacman.d/mirrorlist
+
+[chaotic-aur]
+SigLevel = PackageRequired TrustedOnly
+Include = /etc/pacman.d/chaotic-mirrorlist
+
+# If you want to run 32 bit applications on your x86_64 system,
+# enable the multilib repositories as required here.
+
+#[multilib-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[multilib]
+SigLevel = PackageRequired TrustedOnly
+Include = /etc/pacman.d/mirrorlist
+
+# An example of a custom package repository.  See the pacman manpage for
+# tips on creating your own repositories.
+#[custom]
+#SigLevel = Optional TrustAll
+#Server = file:///home/custompkgs

--- a/Debian.11/Dockerfile
+++ b/Debian.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim as builder
 
 ARG Azure_Powershell_Version=11.2.0
 ARG Helm_Version=v3.7.1
@@ -6,10 +6,18 @@ ARG Octopus_Cli_Legacy_Version=9.1.7
 ARG Octopus_Cli_Version=1.7.1
 ARG Terraform_Version=1.6.6-1
 
-RUN apt-get update \
+ARG User=octoworker
+ARG Group=octoworker
+
+COPY keygen.sh /keygen.sh
+
+RUN groupadd ${Group} \
+    && useradd -m -g ${Group} -s /bin/bash ${User} \
+    && apt-get update \
     && apt-get dist-upgrade \
     && apt-get upgrade \
-    && apt-get install -y apt-transport-https apt-utils augeas-tools ca-certificates curl git gpg gradle jq libc6 libgcc1 libgcc-s1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 lsb-release maven openssh-client rsync software-properties-common unzip wget zlib1g \
+    && apt-get install -y apt-transport-https apt-utils augeas-tools ca-certificates curl docker git gnupg2 gradle jq libc6 libgcc1 libgcc-s1 \
+        libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 lsb-release maven openssh-client pass rsync software-properties-common unzip wget zlib1g \
     && wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && rm -f packages-microsoft-prod.deb \
@@ -29,5 +37,19 @@ RUN apt-get update \
     && curl -sL https://run.linkerd.io/install | sh \
     && cp /root/.linkerd2/bin/linkerd /usr/local/bin \
     && rm -rf /root/.linkerd2 \
-    && pwsh -c 'Install-Module -Force -Name Az -AllowClobber -Scope AllUsers -MaximumVersion "'${Azure_Powershell_Version}'" -Verbose'
+    && pwsh -c 'Install-Module -Force -Name Az -AllowClobber -Scope AllUsers -MaximumVersion "'${Azure_Powershell_Version}'" -Verbose' \
+    && chmod +x /keygen.sh
  
+FROM scratch as intermediary
+
+ARG User=octoworker
+COPY --from=builder / /
+
+USER ${User}
+RUN mkdir -p /home/${User}/.docker/ \
+    && touch /home/${User}/.docker/config.json \
+    && printf "{\n\t\"credsStore\":\"pass\"\n}\n" >> /home/${User}/.docker/config.json \
+    && export GPG_TTY=$(tty) \
+    && /keygen.sh \
+    && fingerprint=$(gpg2 --list-keys | grep -Po '\w{20,}') \
+    && pass init $(echo $fingerprint)

--- a/Debian.11/keygen.sh
+++ b/Debian.11/keygen.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S gpg2 --batch --expert --gen-key
+# Brief: Generate ECC PGP keys for signing (primary key) & encryption (subkey)
+# Run as: chmod +x gpg_ecc-25519_keygen; ./gpg_ecc-25519_keygen
+# Ref: https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
+
+%echo "Generating ECC keys (sign & encr) with no-expiry"
+  %no-protection
+  Key-Type: EDDSA
+    Key-Curve: ed25519
+  Subkey-Type: ECDH
+    Subkey-Curve: cv25519
+  Name-Real: octoworker
+  Expire-Date: 0
+  # Now, let's do a commit here, so that we can later print "done" :-)
+  %commit
+%echo Done

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -1,14 +1,21 @@
-FROM fedora:40
+FROM fedora:40 as builder
 
 ARG Azure_Powershell_Version=11.2.0
 ARG Helm_Version=v3.7.1
 ARG Kubelogin_Version=v0.0.30
 ARG Terraform_Version=1.6.6
 
-RUN dnf remove 'dotnet*' 'aspnet*' 'netstandard*' \
+COPY keygen.sh /keygen.sh
+
+ARG User=octoworker
+ARG Group=octoworker
+
+RUN groupadd ${Group} \
+    && useradd -m -g ${Group} -s /bin/bash ${User} \
+    && dnf remove 'dotnet*' 'aspnet*' 'netstandard*' \
     && dnf update -y \
     && dnf upgrade -y \
-    && dnf install aspnetcore-runtime-8.0 azure-cli curl dotnet-runtime-8.0 dotnet-sdk-8.0 git libicu make nano openssl python3-pip unzip wget -y \
+    && dnf install aspnetcore-runtime-8.0 azure-cli curl dotnet-runtime-8.0 dotnet-sdk-8.0 git gnupg2 libicu make nano openssl pass python3-pip unzip wget -y \
     # Add MSFT Respository
     && wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
     && chmod +x ./dotnet-install.sh \
@@ -68,4 +75,18 @@ RUN dnf remove 'dotnet*' 'aspnet*' 'netstandard*' \
     && cd umoci \
     && make -si DESTDIR=/ install > /dev/null \
     && cd / \
-    && rm -rf umoci \
+    && rm -rf umoci 
+
+FROM scratch as intermediary
+
+ARG User=octoworker
+COPY --from=builder / /
+
+USER ${User}
+RUN mkdir -p /home/${User}/.docker/ \
+    && touch /home/${User}/.docker/config.json \
+    && printf "{\n\t\"credsStore\":\"pass\"\n}\n" >> /home/${User}/.docker/config.json \
+    && export GPG_TTY=$(tty) \
+    && /keygen.sh \
+    && fingerprint=$(gpg2 --list-keys | grep -Po '\w{20,}') \
+    && pass init $(echo $fingerprint)

--- a/Fedora/keygen.sh
+++ b/Fedora/keygen.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S gpg2 --batch --expert --gen-key
+# Brief: Generate ECC PGP keys for signing (primary key) & encryption (subkey)
+# Run as: chmod +x gpg_ecc-25519_keygen; ./gpg_ecc-25519_keygen
+# Ref: https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html
+
+%echo "Generating ECC keys (sign & encr) with no-expiry"
+  %no-protection
+  Key-Type: EDDSA
+    Key-Curve: ed25519
+  Subkey-Type: ECDH
+    Subkey-Curve: cv25519
+  Name-Real: octoworker
+  Expire-Date: 0
+  # Now, let's do a commit here, so that we can later print "done" :-)
+  %commit
+%echo Done

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,18 +4,22 @@ services:
   alpine:
     image: felsokning/worker-tools:alpine.3.19
     build: 
-      dockerfile: /Alpine.3.19/Dockerfile
-      args:
-        - tag=${tag}
+      dockerfile: Dockerfile
+      context: /Alpine.3.19/
   arch:
     image: felsokning/worker-tools:arch
     build: 
-      dockerfile: /Arch/Dockerfile
+      dockerfile: Dockerfile
+      context: /Arch/
+      args:
+        - tag=${tag}
   debian:
     image: felsokning/worker-tools:debian.11
     build: 
-      dockerfile: /Debian.11/Dockerfile
+      dockerfile: Dockerfile
+      context: /Debian.11/
   fedora:
     image: felsokning/worker-tools:fedora.40
     build:
-      dockerfile: /Fedora/Dockerfile
+      dockerfile: Dockerfile
+      context: /Fedora/


### PR DESCRIPTION
This PR modifies the images to support using `pass` to login to docker via a gpg key generated during build. 

It also adds the chaotic repository for Ach, to reduce build legwork and add packages built from AUR (directly).

It also adds a fix for building the images from the docker compose file; however, manual retrieval of the tag is still necessary.